### PR TITLE
商品一覧機能

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,25 +128,27 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <%# 出品されている場合、一覧を表示 %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= link_to "item_path" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# 商品が売れていればsold outを表示しましょう %>
+          
+            <%# <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div> %>
+            <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -154,31 +156,35 @@
           </div>
         </div>
         <% end %>
+        
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
+      
+
+      
+      <%# 出品がない場合、ダミーを表示 %>
+      <% if @items.nil? %> 
+        <li class='list'>
+          <%= link_to '#' do %>
+            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+            <div class='item-price'>
             <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-    </ul>
+          <% end %>
+        </li>
+      <% end %>
+     </ul>
+  
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,8 +127,8 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
       <%# 出品されている場合、一覧を表示 %>
+<% if @items.present?%>
       <% @items.each do |item| %>
       <li class='list'>
           <%= link_to "item_path" do %>
@@ -147,43 +147,53 @@
             <h3 class='item-name'>
               <%= item.name %>
             </h3>
-          <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-        
-      </li>
-      <% end %>
-
-      
-
-      
-      <%# 出品がない場合、ダミーを表示 %>
-      <% if @items.nil? %> 
-        <li class='list'>
-          <%= link_to '#' do %>
-            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                商品を出品してね！
-              </h3>
             <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
+              <span><%= item.price %>円<br><%= item.delivery_fee.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>
               </div>
             </div>
           </div>
+       
           <% end %>
-        </li>
+      </li>
       <% end %>
-     </ul>
+        
+
+    <% else %> 
+          <li class='list'>
+            <%= link_to '#' do %>
+            <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                商品を出品してね！
+              </h3>
+              <div class='item-price'>
+                <span>99999999円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+             <% end %>
+          </li>
+        
+        
+      
+      
+
+      
+
+      
+      <%# 出品がない場合、ダミーを表示 %>
+    <% end %>
+
+      <%# 出品がない場合、ダミーを表示 %>
+    <%# <% end %> 
+     
+    </ul>
   
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
     </div>
     <ul class='item-lists'>
       <%# 出品されている場合、一覧を表示 %>
-<% if @items.present?%>
+      <% if @items.present?%>
       <% @items.each do |item| %>
       <li class='list'>
           <%= link_to "item_path" do %>
@@ -160,7 +160,7 @@
       </li>
       <% end %>
         
-
+    <%# 出品がない場合、ダミーを表示 %>
     <% else %> 
           <li class='list'>
             <%= link_to '#' do %>
@@ -178,23 +178,10 @@
               </div>
             </div>
              <% end %>
-          </li>
-        
-        
-      
-      
-
-      
-
-      
-      <%# 出品がない場合、ダミーを表示 %>
+          </li>       
     <% end %>
-
-      <%# 出品がない場合、ダミーを表示 %>
-    <%# <% end %> 
-     
-    </ul>
-  
+    <%# 出品がない場合、ダミーを表示 %> 
+    </ul> 
   </div>
   <%# /商品一覧 %>
 </div>


### PR DESCRIPTION
# What 
商品一覧表示機能の実装

# Why
furima上で出品された商品を表示するため

# 実装のGYAZO

・商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/b19193e639a99aa273f9716fbf379180

・商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/ee3b9481b3c0364c0e327672e9f8f1f9

# 備考
・売却済みの商品は、画像上に『sold out』の文字が表示されること
については、まだ実装していません。

以上です、よろしくお願いいたします。